### PR TITLE
useBoolean

### DIFF
--- a/src/hooks/useBoolean/index.module.scss
+++ b/src/hooks/useBoolean/index.module.scss
@@ -1,0 +1,40 @@
+.wrapper {
+	height: 90vh;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+
+	.count {
+		font-size: 36px;
+		font-weight: 700;
+		font-family: "Montserrat", sans-serif;
+		color: #F37022;
+	}
+
+	.buttons {
+		display: flex;
+		flex-direction: row;
+		gap: 20px;
+	
+		> button {
+			background-color: #F37022;
+			padding: 10px 15px;
+			border: 1px solid #F37022;
+			background-color: white;
+			color: #F37022;
+			border: 1px solid #F37022;
+			border-radius: 5px;
+			font-size: 14px;
+			font-weight: 500;
+			font-family: "Montserrat", sans-serif;
+			transition: all 0.3s ease;
+		} :hover {
+			background-color: #F37022;
+			border: 1px solid #F37022;
+			color: white;
+			cursor: pointer;
+			scale: 1.1;
+		}
+	}
+}

--- a/src/hooks/useBoolean/useBoolean.stories.tsx
+++ b/src/hooks/useBoolean/useBoolean.stories.tsx
@@ -1,0 +1,38 @@
+// src/hooks/useBoolean/useBoolean.stories.tsx
+
+import React from 'react'
+import { Meta, StoryFn } from '@storybook/react'
+import { useBoolean } from './useBoolean'
+import classes from './index.module.scss'
+
+const Demo = () => {
+  const [on, toggle] = useBoolean()
+
+  return (
+    <div className={classes.wrapper}>
+      <p className={classes.count}>
+        Значение: <code>{String(on)}</code>
+      </p>
+      <div className={classes.buttons}>
+        <button type="button" onClick={() => toggle()} className={classes.button}>
+          Переключить
+        </button>
+        <button type="button" onClick={() => toggle(true)} className={classes.button}>
+          Установить (true)
+        </button>
+        <button type="button" onClick={() => toggle(false)} className={classes.button}>
+          Установить (false)
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default {
+  title: 'Хуки/useBoolean',
+  component: Demo,
+} as Meta
+
+const Template: StoryFn = () => <Demo />
+
+export const Default = Template.bind({})

--- a/src/hooks/useBoolean/useBoolean.ts
+++ b/src/hooks/useBoolean/useBoolean.ts
@@ -1,0 +1,27 @@
+import { useState } from 'react'
+
+/** Тип возвращаемого значения для useBoolean */
+type UseBooleanReturn = [
+  /** Текущее значение булева состояния */
+  value: boolean,
+  /** Функция для переключения булева состояния */
+  toggle: (value?: boolean) => void,
+]
+
+/**
+ * @name useBoolean
+ * @description - Хук предоставляет булево состояние и функцию для переключения булева значения
+ * @category Utilities
+ *
+ * @param {boolean} [initialValue=false] Начальное булево значение
+ * @returns {UseBooleanReturn} Объект, содержащий значение булева состояния и утилитарные функции для его изменения
+ *
+ * @example
+ * const [on, toggle] = useBoolean()
+ */
+export const useBoolean = (initialValue = false): UseBooleanReturn => {
+  const [value, setValue] = useState(initialValue)
+  const toggle = (value?: boolean) => setValue((prevValue) => value ?? !prevValue)
+
+  return [value, toggle]
+}

--- a/src/hooks/useCounter/useCounter.stories.tsx
+++ b/src/hooks/useCounter/useCounter.stories.tsx
@@ -32,7 +32,7 @@ const Demo = () => {
 }
 
 export default {
-  title: 'Hooks/useCounter',
+  title: 'Хуки/useCounter',
   component: Demo,
 } as Meta
 


### PR DESCRIPTION
### **Создание хука `useBoolean`**
Хук `useBoolean `предоставляет булево состояние и функцию для его переключения. Этот хук удобно использовать для управления состояниями, требующими включения или выключения, например, для управления видимостью модальных окон, переключения тем и других двоичных состояний.
### Документация

> Использование хука `useBoolean`

Хук `useBoolean` предоставляет простой способ управления булевым состоянием. По умолчанию, начальное значение состояния — false.

> Параметры

`initialValue` (`boolean`, необязательный): Начальное булево значение состояния. По умолчанию: false.

> Возвращаемое значение

`UseBooleanReturn`: Кортеж, содержащий текущее значение состояния (`boolean`) и функцию для его переключения.
### **История в `Storybook`**
Визуальная демонстрация работы хука `useBoolean` с интерактивным интерфейсом для тестирования