### PR TITLE
useToggle

### DIFF
--- a/src/hooks/useCounter/useCounter.stories.tsx
+++ b/src/hooks/useCounter/useCounter.stories.tsx
@@ -32,7 +32,7 @@ const Demo = () => {
 }
 
 export default {
-  title: 'Hooks/useCounter',
+  title: 'Хуки/useCounter',
   component: Demo,
 } as Meta
 

--- a/src/hooks/useToogle/index.module.scss
+++ b/src/hooks/useToogle/index.module.scss
@@ -1,0 +1,21 @@
+.wrapper {
+	height: 90vh;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	
+	> button {
+		padding: 15px 25px;
+		color: white;
+		border: none;
+		border-radius: 5px;
+		font-size: 18px;
+		font-weight: 500;
+		font-family: "Montserrat", sans-serif;
+		transition: all 0.3s ease;
+	} :hover {
+		cursor: pointer;
+		scale: 1.1;
+	}
+}

--- a/src/hooks/useToogle/useToggle.ts
+++ b/src/hooks/useToogle/useToggle.ts
@@ -1,0 +1,30 @@
+import type { SetStateAction } from 'react'
+import { useReducer } from 'react'
+
+/** Тип возвращаемого значения для useToggle */
+export type UseToggleReturn<Value> = readonly [Value, (value?: Value) => void]
+
+/**
+ * @name useToggle
+ * @description - Хук, создающий переключатель
+ * @category Utilities
+ *
+ * @template Value Тип значения
+ * @param {Value[]} [values=[false, true]] Значения для переключения
+ *
+ * @example
+ * const [on, toggle] = useToggle();
+ *
+ * @example
+ * const [value, toggle] = useToggle(['light', 'dark'] as const);
+ */
+export const useToggle = <Value = boolean>(values: readonly Value[] = [false, true] as Value[]) => {
+  const [[option], toggle] = useReducer((state: Value[], action: SetStateAction<Value | unknown>) => {
+    const value = action instanceof Function ? action(state[0]) : action
+    const index = Math.abs(state.indexOf(value))
+
+    return state.slice(index).concat(state.slice(0, index))
+  }, values as Value[])
+
+  return [option, toggle as (value?: SetStateAction<Value>) => void] as const
+}

--- a/src/hooks/useToogle/useTogle.stories.tsx
+++ b/src/hooks/useToogle/useTogle.stories.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { Meta, StoryFn } from '@storybook/react'
+import { useToggle } from './useToggle'
+import classes from './index.module.scss'
+
+const Demo = () => {
+  const [value, toggle] = useToggle(['blue', 'orange', 'black', 'teal', 'purple'] as const)
+
+  return (
+    <div className={classes.wrapper}>
+      <button type="button" onClick={() => toggle()} className={classes.button} style={{ backgroundColor: value }}>
+        {value}
+      </button>
+    </div>
+  )
+}
+
+export default {
+  title: 'Хуки/useToggle',
+  component: Demo,
+} as Meta
+
+const Template: StoryFn = () => <Demo />
+
+export const Default = Template.bind({})


### PR DESCRIPTION
### **Создание хука `useToggle`**
Хук `useToggle` предоставляет функциональность для переключения между несколькими значениями. Он может быть использован для управления состояниями, требующими циклическое переключение между заданными значениями, например, темами (светлая/тёмная), состояниями (вкл/выкл) и любыми другими наборами значений.
### Документация

> Использование хука `useToggle`

Хук `useToggle` можно использовать с любыми массивами значений. По умолчанию, он переключается между false и true.

> Параметры

`Values` (`readonly Value[]`, необязательный): Массив значений для переключения. Значения могут быть любого типа. По умолчанию: `[false, true]`.

> Возвращаемое значение

`UseToggleReturn<Value>`: Кортеж, содержащий текущее значение и функцию для переключения значений.
### История в `Storybook`
Визуальная демонстрация работы хука `useBoolean` с интерактивным интерфейсом для тестирования