### PR TITLE
useDocumentTitle & useIsomorphicEffect & useMutationObserver

### DIFF
--- a/src/hooks/useCounter/useCounter.stories.tsx
+++ b/src/hooks/useCounter/useCounter.stories.tsx
@@ -32,7 +32,7 @@ const Demo = () => {
 }
 
 export default {
-  title: 'Hooks/useCounter',
+  title: 'Хуки/useCounter',
   component: Demo,
 } as Meta
 

--- a/src/hooks/useDocumentTitle/index.module.scss
+++ b/src/hooks/useDocumentTitle/index.module.scss
@@ -1,0 +1,27 @@
+.wrapper {
+	height: 90vh;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+
+	.title {
+		font-size: 36px;
+		font-weight: 700;
+		font-family: "Montserrat", sans-serif;
+		color: #F37022;
+	}
+
+	> input {
+		padding: 10px 15px;
+		border: 1px solid #F37022;
+		background-color: white;
+		color: #F37022;
+		border: 1px solid #F37022;
+		border-radius: 5px;
+		font-size: 16px;
+		font-weight: 500;
+		font-family: "Montserrat", sans-serif;
+		outline: none;
+	}
+}

--- a/src/hooks/useDocumentTitle/useDocumentTitle.stories.tsx
+++ b/src/hooks/useDocumentTitle/useDocumentTitle.stories.tsx
@@ -1,0 +1,26 @@
+// src/hooks/useDocumentTitle/useDocumentTitle.stories.tsx
+
+import React from 'react'
+import { Meta, StoryFn } from '@storybook/react'
+import { useDocumentTitle } from './useDocumentTitle'
+import classes from './index.module.scss'
+
+const Demo = () => {
+  const [title, setTitle] = useDocumentTitle('Cool Hooks')
+
+  return (
+    <div className={classes.wrapper}>
+      <p className={classes.title}>Заголовок: {title}</p>
+      <input defaultValue={title} onChange={(e) => setTitle(e.target.value)} />
+    </div>
+  )
+}
+
+export default {
+  title: 'Хуки/useDocumentTitle',
+  component: Demo,
+} as Meta
+
+const Template: StoryFn = () => <Demo />
+
+export const Default = Template.bind({})

--- a/src/hooks/useDocumentTitle/useDocumentTitle.tsx
+++ b/src/hooks/useDocumentTitle/useDocumentTitle.tsx
@@ -1,0 +1,69 @@
+import { useRef, useState } from 'react'
+import { useMutationObserver } from '../useMutationObserver/useMutationObserver'
+import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect/useIsomorphicLayoutEffect'
+
+/** Тип опций для хука useDocumentTitle */
+export interface UseDocumentTitleOptions {
+  /** Восстановить предыдущий заголовок при размонтировании компонента */
+  restoreOnUnmount?: boolean
+}
+
+/** Тип возвращаемого значения хука useDocumentTitle */
+export type UseDocumentTitleReturn = [
+  /** Текущий заголовок */
+  title: string,
+
+  /** Функция для обновления заголовка */
+  setTitle: (title: string) => void,
+]
+
+/**
+ * @name useDocumentTitle
+ * @description - Хук, который управляет заголовком документа и позволяет его обновлять
+ * @category Browser
+ *
+ * @param {string} [value] Начальный заголовок. Если не указан, будет использован текущий заголовок документа.
+ * @param {boolean} [options.restoreOnUnmount] Восстановить предыдущий заголовок при размонтировании компонента.
+ * @returns {UseDocumentTitleReturn} Массив, содержащий текущий заголовок и функцию для его обновления.
+ *
+ * @example
+ * const [title, setTitle] = useDocumentTitle();
+ */
+export function useDocumentTitle(value?: string, options?: UseDocumentTitleOptions): UseDocumentTitleReturn {
+  const prevTitleRef = useRef(document.title)
+  const [title, setTitle] = useState(value ?? document.title)
+
+  useMutationObserver(
+    () => {
+      if (document.title !== title) {
+        setTitle(document.title)
+      }
+    },
+    { childList: true },
+    document.head.querySelector('title'),
+  )
+
+  useIsomorphicLayoutEffect(() => {
+    if (options?.restoreOnUnmount) {
+      return () => {
+        document.title = prevTitleRef.current
+      }
+    }
+  }, [options?.restoreOnUnmount])
+
+  const set = (value: string) => {
+    const updatedValue = value.trim()
+    if (updatedValue.length > 0) {
+      document.title = updatedValue
+      setTitle(updatedValue)
+    }
+  }
+
+  useIsomorphicLayoutEffect(() => {
+    if (typeof value === 'string') {
+      set(value)
+    }
+  }, [value])
+
+  return [title, set]
+}

--- a/src/hooks/useIsomorphicLayoutEffect/useIsomorphicLayoutEffect.tsx
+++ b/src/hooks/useIsomorphicLayoutEffect/useIsomorphicLayoutEffect.tsx
@@ -1,0 +1,12 @@
+import { isClient } from '@/utils/helpers'
+import { useEffect, useLayoutEffect } from 'react'
+
+/**
+ * @name useIsomorphicLayoutEffect
+ * @description - Хук, условно выбирающий либо `useLayoutEffect`, либо `useEffect` в зависимости от среды выполнения
+ * @category Жизненный цикл
+ *
+ * @example
+ * useIsomorphicLayoutEffect(() => console.log('эффект'), [])
+ */
+export const useIsomorphicLayoutEffect = isClient ? useLayoutEffect : useEffect

--- a/src/hooks/useMutationObserver/useMutationObserver.ts
+++ b/src/hooks/useMutationObserver/useMutationObserver.ts
@@ -1,0 +1,34 @@
+import type { RefObject } from 'react'
+import { useEffect, useRef } from 'react'
+
+/**
+ * Пользовательский хук React, который наблюдает за мутациями на указанном целевом элементе и вызывает обратный вызов, когда происходят мутации.
+ *
+ * @param {MutationCallback} callback - Функция, которая будет вызвана при обнаружении мутации.
+ * @param {MutationObserverInit} options - Опции для настройки MutationObserver.
+ * @param {HTMLElement | (() => HTMLElement) | null} target - Целевой элемент для наблюдения за мутациями.
+ * @return {RefObject<Element>} Ссылка на наблюдаемый элемент.
+ */
+export function useMutationObserver<Element extends HTMLElement>(
+  callback: MutationCallback,
+  options: MutationObserverInit,
+  target?: HTMLElement | (() => HTMLElement) | null,
+) {
+  const observer = useRef<MutationObserver>()
+  const ref: RefObject<Element> = useRef(null)
+
+  useEffect(() => {
+    const targetElement = typeof target === 'function' ? target() : target
+
+    if (targetElement || ref.current) {
+      observer.current = new MutationObserver(callback)
+      observer.current.observe(targetElement || ref.current!, options)
+    }
+
+    return () => {
+      observer.current?.disconnect()
+    }
+  }, [callback, options])
+
+  return ref
+}

--- a/src/utils/helpers/index.ts
+++ b/src/utils/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './isClient'

--- a/src/utils/helpers/isClient.ts
+++ b/src/utils/helpers/isClient.ts
@@ -1,0 +1,1 @@
+export const isClient = !!(typeof window !== 'undefined' && window?.document?.createElement)


### PR DESCRIPTION
### **Создание хука `useDocumentTitle`**
Хук `useDocumentTitle `предоставляет функциональность для управления заголовком документа в веб-приложении. Он позволяет вам не только установить начальный заголовок для страницы, но и обновлять его динамически, а также восстанавливать предыдущий заголовок при размонтировании компонента, если это требуется.

### Документация

> Использование хука `useDocumentTitle`

Хук `useDocumentTitle` можно использовать для установки и обновления заголовка документа, а также для сохранения и восстановления предыдущего заголовка при необходимости. Это полезно для управления заголовком страницы в зависимости от состояния компонента или приложения.

> Параметры

`value` (`string`, необязательный): Начальный заголовок документа. Если не указан, используется текущий заголовок документа.

`options.restoreOnUnmount` (`boolean`, необязательный): Если установлено в true, при размонтировании компонента будет восстановлен заголовок, который был до монтирования компонента. По умолчанию значение `false`.

> Возвращаемое значение

`UseDocumentTitleReturn`: Кортеж, содержащий текущее значение заголовка и функцию для его обновления.

`title` (`string`): Текущий заголовок документа.
`setTitle ((title: string) => void)`: Функция для установки нового заголовка документа.
### История в Storybook
Визуальная демонстрация работы хука `useDocumentTitle` с интерактивным интерфейсом для тестирования различных заголовков и опций.