### PR TITLE
useRenderMetrics

### DIFF
--- a/src/hooks/useCounter/useCounter.stories.tsx
+++ b/src/hooks/useCounter/useCounter.stories.tsx
@@ -32,7 +32,7 @@ const Demo = () => {
 }
 
 export default {
-  title: 'Hooks/useCounter',
+  title: 'Хуки/useCounter',
   component: Demo,
 } as Meta
 

--- a/src/hooks/useRenderMetrics/index.module.scss
+++ b/src/hooks/useRenderMetrics/index.module.scss
@@ -1,0 +1,47 @@
+.wrapper {
+	height: 90vh;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	width: 100%;
+
+	.title {
+		font-size: 36px;
+		font-weight: 700;
+		font-family: "Montserrat", sans-serif;
+		color: #F37022;
+	}
+	.metrics {
+		width: 400px;
+		> p {
+			font-size: 18px;
+			font-weight: 500;
+			font-family: "Montserrat", sans-serif;
+			>span{
+				color: #F37022;
+			}
+		}
+	}
+
+	> button {
+		background-color: #F37022;
+		padding: 10px 15px;
+		border: 1px solid #F37022;
+		background-color: white;
+		color: #F37022;
+		border: 1px solid #F37022;
+		border-radius: 5px;
+		font-size: 14px;
+		font-weight: 500;
+		font-family: "Montserrat", sans-serif;
+		transition: all 0.3s ease;
+		&:hover {
+		background-color: #F37022;
+		border: 1px solid #F37022;
+		color: white;
+		cursor: pointer;
+		scale: 1.1;
+	}
+}
+}

--- a/src/hooks/useRenderMetrics/useRenderMetrics.stories.tsx
+++ b/src/hooks/useRenderMetrics/useRenderMetrics.stories.tsx
@@ -1,0 +1,55 @@
+// src/hooks/useDocumentTitle/useDocumentTitle.stories.tsx
+
+import React, { useState } from 'react'
+import { Meta, StoryFn } from '@storybook/react'
+import classes from './index.module.scss'
+import { useRenderMetrics } from './useRenderMetrics'
+
+const Demo = () => {
+  const [count, setCount] = useState<number>(0)
+  const renderMetrics = useRenderMetrics('Счётчик')
+
+  const handleClick = () => {
+    setCount((prevCount) => prevCount + 1)
+  }
+
+  return (
+    <div className={classes.wrapper}>
+      <p className={classes.title}>Счетчик: {count}</p>
+      <button onClick={handleClick} className={classes.button}>
+        Увеличить счетчик
+      </button>
+      {renderMetrics && (
+        <div className={classes.metrics}>
+          <h2 className={classes.title}>Метрики рендеров:</h2>
+          <p>
+            Имя: <span>{renderMetrics.name}</span>
+          </p>
+          <p>
+            Количество рендеров: <span>{renderMetrics.renders}</span>
+          </p>
+          <p>
+            Время с последнего рендера: <span>{renderMetrics.sinceLastRender} секунд</span>
+          </p>
+          <p>
+            Временная метка: <span>{renderMetrics.timestamp}</span>
+          </p>
+          {renderMetrics.memoryUsage && (
+            <p>
+              Использование памяти: <span>{renderMetrics.memoryUsage}</span>
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default {
+  title: 'Хуки/useRenderMetrics',
+  component: Demo,
+} as Meta
+
+const Template: StoryFn = () => <Demo />
+
+export const Default = Template.bind({})

--- a/src/hooks/useRenderMetrics/useRenderMetrics.tsx
+++ b/src/hooks/useRenderMetrics/useRenderMetrics.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef, useCallback, useMemo } from 'react'
+
+/** Интерфейс для метрик рендеров */
+interface RenderMetrics {
+  name: string
+  renders: number
+  sinceLastRender: number
+  timestamp: string
+  memoryUsage?: string
+}
+
+/** Расширение интерфейса Performance для включения опциональной памяти */
+interface PerformanceWithMemory extends Performance {
+  memory?: {
+    usedJSHeapSize: number
+  }
+}
+
+/**
+ * @name useRenderMetrics
+ * @description - Хук, который отслеживает метрики рендеров компонента, включая количество рендеров,
+ * время с последнего рендера и использование памяти.
+ * @param {string} [name='Unknown'] Имя компонента для идентификации в логах.
+ * @param {boolean} [logMetrics=true] Флаг для включения/выключения логирования метрик.
+ * @returns {RenderMetrics | null} Объект с метриками рендеров или null в продакшен-окружении.
+ * @example
+ * const renderMetrics = useRenderMetrics('MyComponent');
+ */
+export function useRenderMetrics(name = 'Unknown', logMetrics = true): RenderMetrics | null {
+  // Счетчик рендеров
+  const renderCount = useRef<number>(0)
+  // Время последнего рендера
+  const lastRenderTime = useRef<number | null>(null)
+  // Текущее время
+  const currentTime: number = Date.now()
+
+  // Увеличиваем счетчик рендеров
+  renderCount.current++
+
+  // Обновляем время последнего рендера при каждом рендере
+  useEffect(() => {
+    lastRenderTime.current = Date.now()
+  })
+
+  // Время с последнего рендера в секундах
+  const sinceLastRender: number = lastRenderTime.current ? (currentTime - lastRenderTime.current) / 1000 : 0
+
+  // Форматирование использования памяти
+  const formatMemoryUsage = useCallback((memoryUsage: number): string => {
+    const mb = memoryUsage / (1024 * 1024)
+    const gb = memoryUsage / (1024 * 1024 * 1024)
+    if (gb >= 1) {
+      return `${gb.toFixed(2)} GB`
+    } else {
+      return `${mb.toFixed(2)} MB`
+    }
+  }, [])
+
+  // Использование памяти
+  let memoryUsage: string | undefined = undefined
+  const performance = window.performance as PerformanceWithMemory
+
+  // Проверяем, поддерживается ли измерение памяти
+  if (performance.memory) {
+    memoryUsage = formatMemoryUsage(performance.memory.usedJSHeapSize)
+  }
+
+  // Форматирование временной метки в читаемую строку
+  const formatTimestamp = useCallback((timestamp: number): string => {
+    const date = new Date(timestamp)
+
+    return date.toLocaleString()
+  }, [])
+
+  // Мемоизируем объект метрик для оптимизации
+  const metrics = useMemo<RenderMetrics>(
+    () => ({
+      name,
+      renders: renderCount.current,
+      sinceLastRender,
+      timestamp: formatTimestamp(currentTime),
+      memoryUsage,
+    }),
+    [name, renderCount.current, sinceLastRender, currentTime, memoryUsage, formatTimestamp],
+  )
+
+  // Если не в продакшен-окружении и логирование включено, логируем метрики
+  if (process.env.NODE_ENV !== 'production' && logMetrics) {
+    console.log(metrics)
+  }
+
+  return metrics
+}


### PR DESCRIPTION
### **Создание хука `useRenderMetrics`**
Хук `useRenderMetrics` предоставляет функциональность для отслеживания и логирования метрик рендеров `React-компонента`. Он помогает разработчикам собирать информацию о частоте рендеров, времени с последнего рендера и использовании памяти, что полезно для оптимизации производительности и анализа работы компонентов.
### Документация

> Использование хука `useRenderMetrics` 

Хук `useRenderMetrics` предназначен для сбора и логирования метрик рендеров React-компонента. Он полезен для мониторинга частоты рендеров, времени между рендерами и использования памяти, что может помочь в отладке и оптимизации приложений.

> Параметры

`name (string, необязательный)`: Имя компонента для идентификации в логах. По умолчанию "`Unknown`".
`logMetrics (boolean, необязательный)`: Флаг для включения/выключения логирования метрик. По умолчанию `true`. В продакшен-окружении логирование всегда выключено.

> Возвращаемое значение

- `RenderMetrics | null`: Объект с метриками рендеров или null, если мы находимся в продакшен-окружении или `logMetrics` установлен в `false`.
- `RenderMetrics`:
- `name (string)`: Имя компонента.
- `renders (number)`: Количество рендеров компонента.
- `sinceLastRender (number)`: Время в секундах с последнего рендера.
- `timestamp (string)`: Временная метка текущего рендера в читаемом формате.
- `memoryUsage (string | undefined)`: Использование памяти в МБ или ГБ, если поддерживается браузером.
### История в `Storybook`
Визуальная демонстрация работы хука `useRenderMetrics` с интерактивным интерфейсом для тестирования