### PR TITLE
useLocalStorage

### DIFF
--- a/src/hooks/useCounter/useCounter.stories.tsx
+++ b/src/hooks/useCounter/useCounter.stories.tsx
@@ -32,7 +32,7 @@ const Demo = () => {
 }
 
 export default {
-  title: 'Hooks/useCounter',
+  title: 'Хуки/useCounter',
   component: Demo,
 } as Meta
 

--- a/src/hooks/useLocalStorage/index.module.scss
+++ b/src/hooks/useLocalStorage/index.module.scss
@@ -1,0 +1,40 @@
+.wrapper {
+	height: 90vh;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+
+	.description {
+		font-size: 36px;
+		font-weight: 700;
+		font-family: "Montserrat", sans-serif;
+		color: #F37022;
+	}
+
+	.buttons {
+		display: flex;
+		flex-direction: row;
+		gap: 20px;
+	
+		> button {
+			background-color: #F37022;
+			padding: 10px 15px;
+			border: 1px solid #F37022;
+			background-color: white;
+			color: #F37022;
+			border: 1px solid #F37022;
+			border-radius: 5px;
+			font-size: 14px;
+			font-weight: 500;
+			font-family: "Montserrat", sans-serif;
+			transition: all 0.3s ease;
+		} :hover {
+			background-color: #F37022;
+			border: 1px solid #F37022;
+			color: white;
+			cursor: pointer;
+			scale: 1.1;
+		}
+	}
+}

--- a/src/hooks/useLocalStorage/useLocalStorage.stories.tsx
+++ b/src/hooks/useLocalStorage/useLocalStorage.stories.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useRef } from 'react'
+import { Meta, StoryFn } from '@storybook/react'
+import classes from './index.module.scss'
+import useLocalStorage from './useLocalStorage'
+import createDrawing from '@/utils/helpers/createDrawing'
+
+const Demo = () => {
+  const [drawing, saveDrawing] = useLocalStorage('drawing', null as string | null)
+  const ref = useRef<HTMLCanvasElement | null>(null)
+
+  const handleSaveDrawing = (drawing: string) => {
+    saveDrawing(drawing)
+  }
+
+  useEffect(() => {
+    createDrawing(ref.current, drawing, handleSaveDrawing)
+  }, [drawing, handleSaveDrawing])
+
+  return (
+    <section className={classes.wrapper}>
+      <div className={classes.buttons}>
+        <button className="link" onClick={() => window.location.reload()}>
+          Перегрузить страницу
+        </button>
+        <button
+          className="link"
+          onClick={() => {
+            window.localStorage.clear()
+            window.location.reload()
+          }}>
+          Очистить Local Storage
+        </button>
+      </div>
+      <figure>
+        <canvas
+          ref={ref}
+          width={400}
+          height={400}
+          style={{ border: '1px solid red', borderRadius: '10px', backgroundColor: '#F37022' }}
+        />
+        <figcaption
+          style={{
+            textAlign: 'center',
+            color: '#F37022',
+            fontSize: '20px',
+          }}>
+          (Нарисуйте что-нибудь)
+        </figcaption>
+      </figure>
+    </section>
+  )
+}
+
+export default {
+  title: 'Хуки/useLocalStorage',
+  component: Demo,
+} as Meta
+
+const Template: StoryFn = () => <Demo />
+
+export const Default = Template.bind({})

--- a/src/hooks/useLocalStorage/useLocalStorage.tsx
+++ b/src/hooks/useLocalStorage/useLocalStorage.tsx
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useSyncExternalStore } from 'react'
+
+/** Тип действия для установки состояния, который может быть либо новым значением, либо функцией, принимающей предыдущее состояние и возвращающей новое значение */
+type SetStateAction<T> = T | ((prevState: T) => T)
+
+/**
+ * Получает значение из localStorage по заданному ключу.
+ * @param key - Ключ для получения значения из localStorage.
+ * @returns Значение, сохраненное в localStorage, или null, если значения нет или произошла ошибка.
+ */
+function getLocalStorageItem(key: string): string | null {
+  try {
+    return localStorage.getItem(key)
+  } catch (e) {
+    console.warn(e)
+
+    return null
+  }
+}
+
+/**
+ * Устанавливает значение в localStorage по заданному ключу.
+ * @param key - Ключ для сохранения значения в localStorage.
+ * @param value - Значение для сохранения.
+ */
+function setLocalStorageItem(key: string, value: unknown): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(value))
+  } catch (e) {
+    console.warn(e)
+  }
+}
+
+/**
+ * Удаляет значение из localStorage по заданному ключу.
+ * @param key - Ключ для удаления значения из localStorage.
+ */
+function removeLocalStorageItem(key: string): void {
+  try {
+    localStorage.removeItem(key)
+  } catch (e) {
+    console.warn(e)
+  }
+}
+
+/**
+ * Подписывается на события изменения localStorage.
+ * @param callback - Функция, которая будет вызываться при изменении localStorage.
+ * @returns Функция для отписки от событий.
+ */
+function useLocalStorageSubscribe(callback: () => void): () => void {
+  window.addEventListener('storage', callback)
+
+  return () => window.removeEventListener('storage', callback)
+}
+
+/**
+ * Возвращает фиктивное значение для серверного снапшота, так как localStorage недоступен на сервере.
+ * @returns null
+ */
+function getLocalStorageServerSnapshot(): null {
+  return null
+}
+
+/**
+ * Хук для управления состоянием с использованием localStorage.
+ * @param key - Ключ для хранения значения в localStorage.
+ * @param initialValue - Начальное значение, используемое, если в localStorage нет значения по заданному ключу.
+ * @returns Массив, содержащий текущее значение и функцию для его обновления.
+ */
+function useLocalStorage<T>(key: string, initialValue: T): [T, (value: SetStateAction<T>) => void] {
+  const getSnapshot = () => getLocalStorageItem(key)
+
+  const store = useSyncExternalStore(useLocalStorageSubscribe, getSnapshot, getLocalStorageServerSnapshot)
+
+  const setState = useCallback(
+    (value: SetStateAction<T>) => {
+      try {
+        const nextState =
+          typeof value === 'function' ? (value as (prevState: T) => T)(JSON.parse(store ?? 'null')) : value
+
+        if (nextState === undefined || nextState === null) {
+          removeLocalStorageItem(key)
+        } else {
+          setLocalStorageItem(key, nextState)
+        }
+      } catch (e) {
+        console.warn(e)
+      }
+    },
+    [key, store],
+  )
+
+  useEffect(() => {
+    if (getLocalStorageItem(key) === null && typeof initialValue !== 'undefined') {
+      setLocalStorageItem(key, initialValue)
+    }
+  }, [key, initialValue])
+
+  const storedValue = store ? JSON.parse(store) : initialValue
+
+  return [storedValue, setState]
+}
+
+export default useLocalStorage

--- a/src/utils/helpers/createDrawing.ts
+++ b/src/utils/helpers/createDrawing.ts
@@ -1,0 +1,62 @@
+export default function createDrawing(
+  canvas: HTMLCanvasElement | null,
+  initialDrawing: string | null,
+  saveDrawing: (drawing: string) => void,
+): void {
+  if (!canvas) return
+
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return
+  ctx.strokeStyle = 'white'
+
+  let drawing: [number, number, string][] = initialDrawing ? JSON.parse(initialDrawing) : []
+
+  if (drawing.length) {
+    drawing.forEach(([x, y, type]) => {
+      ctx?.lineTo(x, y)
+      if (type === 'end') {
+        ctx?.stroke()
+        ctx?.beginPath()
+      }
+    })
+  }
+
+  let isDrawing = false
+  let points: Array<[number | null, number | null, string]> = []
+
+  canvas.onmousedown = () => {
+    isDrawing = true
+    ctx?.beginPath()
+  }
+
+  canvas.onmousemove = (e: MouseEvent) => {
+    if (!isDrawing) return
+    const rect = canvas.getBoundingClientRect()
+    const x = e.clientX - rect.left
+    const y = e.clientY - rect.top
+    ctx?.lineTo(x, y)
+    ctx?.stroke()
+    points.push([x, y, 'move'])
+  }
+
+  canvas.onmouseup = () => {
+    if (!isDrawing) return
+    isDrawing = false
+    ctx?.stroke()
+    ctx?.closePath()
+    points.push([null, null, 'end'])
+    saveDrawing(JSON.stringify(points))
+    points = []
+  }
+
+  canvas.onmouseout = () => {
+    if (isDrawing) {
+      isDrawing = false
+      ctx?.stroke()
+      ctx?.closePath()
+      points.push([null, null, 'end'])
+      saveDrawing(JSON.stringify(points))
+      points = []
+    }
+  }
+}


### PR DESCRIPTION
### **Создание хука `useLocalStorage`**
Хук `useLocalStorage` предоставляет функциональность для управления состоянием с использованием `localStorage`. Он позволяет сохранять, обновлять и удалять значения в `localStorage`, а также синхронизировать состояние между разными вкладками браузера. Это полезно для сохранения пользовательских настроек, состояния приложения и других данных, которые должны сохраняться между сессиями.

### Документация

> Использование хука `useLocalStorage`

Хук `useLocalStorage` предназначен для управления состоянием с использованием `localStorage`. Он позволяет сохранять, обновлять и удалять значения в `localStorage`, а также синхронизировать состояние между разными вкладками браузера.

> Параметры

`key (string)`: Ключ для хранения значения в `localStorage`.
`initialValue (T)`: Начальное значение, используемое, если в `localStorage` нет значения по заданному ключу.

> Возвращаемое значение

Массив, содержащий текущее значение и функцию для его обновления:
`[T, (value: SetStateAction<T>) => void]`:
`T`: Текущее значение, сохраненное в `localStorage` или начальное значение.
`(value: SetStateAction<T>) => void`: Функция для обновления значения. Принимает либо новое значение, либо функцию, которая принимает предыдущее состояние и возвращает новое значение.
### История в `Storybook`
Визуальная демонстрация работы хука `useLocalStorage` с интерактивным интерфейсом для тестирования