### PR TITLE
usePrevious

### DIFF
--- a/src/hooks/usePrevious/index.module.scss
+++ b/src/hooks/usePrevious/index.module.scss
@@ -1,0 +1,47 @@
+.wrapper {
+	height: 90vh;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+
+	.count, .previousCount {
+		font-weight: 700;
+		font-family: "Montserrat", sans-serif;
+		color: #F37022;
+	}
+
+	.count {
+		font-size: 36px;
+	}
+
+	.previousCount {
+		font-size: 22px;
+	}
+
+	.buttons {
+		display: flex;
+		flex-direction: row;
+		gap: 20px;
+	
+		> button {
+			background-color: #F37022;
+			padding: 10px 15px;
+			border: 1px solid #F37022;
+			background-color: white;
+			color: #F37022;
+			border: 1px solid #F37022;
+			border-radius: 5px;
+			font-size: 14px;
+			font-weight: 500;
+			font-family: "Montserrat", sans-serif;
+			transition: all 0.3s ease;
+		} :hover {
+			background-color: #F37022;
+			border: 1px solid #F37022;
+			color: white;
+			cursor: pointer;
+			scale: 1.1;
+		}
+	}
+}

--- a/src/hooks/usePrevious/usePrevious.stories.tsx
+++ b/src/hooks/usePrevious/usePrevious.stories.tsx
@@ -1,0 +1,39 @@
+// src/hooks/usePrevious/usePrevious.stories.tsx
+
+import React, { useState } from 'react'
+import { Meta, StoryFn } from '@storybook/react'
+import classes from './index.module.scss'
+import { usePrevious } from './usePrevious'
+
+const Demo = () => {
+  const [count, setCount] = useState(0)
+  const previousCount = usePrevious(count)
+
+  return (
+    <div className={classes.wrapper}>
+      <p className={classes.count}>
+        Текущее значение: <code>{count}</code>
+      </p>
+      <p className={classes.previousCount}>
+        Предыдущее значение: <code>{previousCount ?? 'Нет предыдущего значения'}</code>
+      </p>
+      <div className={classes.buttons}>
+        <button type="button" onClick={() => setCount(count + 1)} className={classes.button}>
+          Увеличить
+        </button>
+        <button type="button" onClick={() => setCount(count - 1)} className={classes.button}>
+          Уменьшить
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default {
+  title: 'Хуки/usePrevious',
+  component: Demo,
+} as Meta
+
+const Template: StoryFn = () => <Demo />
+
+export const Default = Template.bind({})

--- a/src/hooks/usePrevious/usePrevious.tsx
+++ b/src/hooks/usePrevious/usePrevious.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * @name usePrevious
+ * @description Хук для сохранения предыдущего значения переменной между рендерами.
+ * @category Utilities
+ *
+ * @template T - Тип сохраняемого значения.
+ *
+ * @param {T} value - Текущее значение.
+ *
+ * @returns {T | undefined} - Предыдущее значение или undefined, если предыдущего значения нет.
+ *
+ * @example
+ * const ExampleComponent: React.FC = () => {
+ *   const [count, setCount] = useState(0)
+ *   const previousCount = usePrevious(count)
+ *
+ *   return (
+ *     <div>
+ *       <p>Current count: {count}</p>
+ *       <p>Previous count: {previousCount ?? 'No previous value'}</p>
+ *       <button onClick={() => setCount(count + 1)}>Increment</button>
+ *     </div>
+ *   )
+ * }
+ */
+export function usePrevious<T>(value: T): T | undefined {
+  // Создаем ref для хранения предыдущего значения
+  const ref = useRef<T | undefined>(undefined)
+
+  // Используем useEffect для обновления ref при изменении value
+  useEffect(() => {
+    ref.current = value
+  }, [value])
+
+  // Возвращаем предыдущее значение
+  return ref.current
+}


### PR DESCRIPTION
### Создание хука `usePrevious`
Хук `usePrevious` предоставляет функциональность для сохранения предыдущего значения переменной между рендерами. Этот хук полезен для сравнения текущего значения с предыдущим, например, при отслеживании изменений состояния.

### Документация

> Использование хука `usePrevious`

Хук `usePrevious` предназначен для сохранения предыдущего значения переменной между рендерами. Он позволяет отслеживать изменения значений и использовать предыдущие значения в логике компонента.

> Параметры

`value (T)` : Текущее значение.

> Возвращаемое значение

`T | undefined` : Предыдущее значение или `undefined`, если предыдущего значения нет.
### История в Storybook
Визуальная демонстрация работы хука `usePrevious` с интерактивным интерфейсом для тестирования.
### Примеры использования

- Отслеживание изменений состояния: Сравнение текущего значения состояния с предыдущим для выполнения определенной логики.
- Отображение истории значений: Отображение предыдущих значений в интерфейсе для пользователя.
- Анимации и переходы: Использование предыдущих значений для плавных анимаций и переходов.