### PR TITLE
useHover

### DIFF
--- a/src/hooks/useHover/index.module.scss
+++ b/src/hooks/useHover/index.module.scss
@@ -1,0 +1,34 @@
+.wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background-color: #f5f5f5;
+}
+
+.hoverBox {
+  width: 300px;
+  aspect-ratio: 1 / 1;
+  border: 2px solid #333;
+	border-radius: 10px;
+  display: flex;
+	padding: 20px;
+  justify-content: center;
+  align-items: center;
+  transition: background-color 0.3s, color 0.3s;
+  cursor: pointer;
+}
+
+.hoverBox:hover {
+  border-color: #545656;
+}
+
+.hovered {
+  background-color: #F37022;
+  color: white;
+}
+
+.text {
+  font-size: 20px;
+  text-align: center;
+}

--- a/src/hooks/useHover/useHover.stories.tsx
+++ b/src/hooks/useHover/useHover.stories.tsx
@@ -1,0 +1,31 @@
+// src/hooks/useHover/useHover.stories.tsx
+
+import React from 'react'
+import { Meta, StoryFn } from '@storybook/react'
+import { useHover } from './useHover'
+import classes from './index.module.scss'
+
+const Demo = () => {
+  const { isHovered, ref } = useHover<HTMLDivElement>({
+    initialIsHovered: false,
+    useMouseEnter: true,
+    useMouseLeave: true,
+  })
+
+  return (
+    <div className={classes.wrapper}>
+      <div ref={ref} className={`${classes.hoverBox} ${isHovered ? classes.hovered : ''}`}>
+        <p className={classes.text}>{isHovered ? 'Мышь над элементом' : 'Мышь не над элементом'}</p>
+      </div>
+    </div>
+  )
+}
+
+export default {
+  title: 'Хуки/useHover',
+  component: Demo,
+} as Meta
+
+const Template: StoryFn = () => <Demo />
+
+export const Default = Template.bind({})

--- a/src/hooks/useHover/useHover.ts
+++ b/src/hooks/useHover/useHover.ts
@@ -1,0 +1,80 @@
+import { useState, useRef, useEffect, RefObject } from 'react'
+
+/** Опции для useHover */
+export interface UseHoverOptions {
+  /** Начальное состояние наведения (по умолчанию: false) */
+  initialIsHovered?: boolean
+  /** Указать, использовать ли обработчик 'mouseenter' вместо 'mouseover' */
+  useMouseEnter?: boolean
+  /** Указать, использовать ли обработчик 'mouseleave' вместо 'mouseout' */
+  useMouseLeave?: boolean
+}
+
+/** Возвращаемый тип useHover */
+export interface UseHoverReturn<T extends HTMLElement> {
+  /** Булево значение, указывающее, наведена ли мышь на элемент */
+  isHovered: boolean
+  /** Ссылка на элемент, для которого отслеживается состояние наведения */
+  ref: RefObject<T>
+}
+
+/**
+ * @name useHover
+ * @description - Хук, управляющий состоянием наведения на элемент
+ * @category Utilities
+ *
+ * @param {UseHoverOptions} [options] Опции для настройки поведения хука
+ * @param {boolean} [options.initialIsHovered=false] Начальное состояние наведения
+ * @param {boolean} [options.useMouseEnter=false] Указать, использовать ли обработчик 'mouseenter' вместо 'mouseover'
+ * @param {boolean} [options.useMouseLeave=false] Указать, использовать ли обработчик 'mouseleave' вместо 'mouseout'
+ * @returns {UseHoverReturn<T>} Объект, содержащий текущее состояние наведения и ссылку на элемент
+ *
+ * @example
+ * const { isHovered, ref } = useHover<HTMLDivElement>();
+ *
+ * <div ref={ref}>
+ *   {isHovered ? 'Мышь над элементом' : 'Мышь не над элементом'}
+ * </div>
+ *
+ * @example
+ * const { isHovered, ref } = useHover<HTMLButtonElement>({ initialIsHovered: true });
+ *
+ * <button ref={ref}>
+ *   {isHovered ? 'Наведено' : 'Не наведено'}
+ * </button>
+ */
+export function useHover<T extends HTMLElement>(options?: UseHoverOptions): UseHoverReturn<T> {
+  const { initialIsHovered = false, useMouseEnter = false, useMouseLeave = false } = options || {}
+
+  // Состояние для отслеживания, наведена ли мышь
+  const [isHovered, setIsHovered] = useState<boolean>(initialIsHovered)
+
+  // Ссылка на элемент, к которому будет привязан обработчик событий
+  const ref = useRef<T>(null)
+
+  // Обработчики событий для наведения и ухода мыши
+  const handleMouseOver = () => setIsHovered(true)
+  const handleMouseOut = () => setIsHovered(false)
+
+  useEffect(() => {
+    const node = ref.current
+
+    if (node) {
+      // Используем либо mouseenter/mouseleave, либо mouseover/mouseout в зависимости от опций
+      const mouseEnterEvent = useMouseEnter ? 'mouseenter' : 'mouseover'
+      const mouseLeaveEvent = useMouseLeave ? 'mouseleave' : 'mouseout'
+
+      // Добавляем обработчики событий
+      node.addEventListener(mouseEnterEvent, handleMouseOver)
+      node.addEventListener(mouseLeaveEvent, handleMouseOut)
+
+      // Функция очистки для удаления обработчиков событий
+      return () => {
+        node.removeEventListener(mouseEnterEvent, handleMouseOver)
+        node.removeEventListener(mouseLeaveEvent, handleMouseOut)
+      }
+    }
+  }, [useMouseEnter, useMouseLeave])
+
+  return { isHovered, ref }
+}


### PR DESCRIPTION
### Создание хука `useHover`
Хук `useHover` предоставляет функциональность для отслеживания состояния наведения (`hover`) на элементы. Он позволяет легко управлять состоянием наведения на любом `HTML-элементе`, предоставляя простой `API` и возможность настройки.

### Документация

> Использование хука `useHover`

Хук `useHover` позволяет отслеживать, находится ли мышь над определённым элементом. Это может быть полезно для реализации интерактивных интерфейсов, где важно реагировать на действия пользователя, такие как наведение курсора на элементы.

> Параметры

`options (UseHoverOptions)` : Объект настроек хука:
`initialIsHovered (boolean)` : Начальное состояние наведения (по умолчанию `false`).
`useMouseEnter (boolean)` : Флаг для включения события mouseenter (по умолчанию `true`).
`useMouseLeave (boolean)` : Флаг для включения события mouseleave (по умолчанию `true`).

> Возвращаемое значение

`ref (RefObject<T>)` : Ссылка на элемент, наведение на который необходимо отслеживать.
`isHovered (boolean)` : Логическое значение, указывающее, находится ли мышь над элементом.
### История в `Storybook`
Визуальная демонстрация работы хука `useHover` с интерактивным интерфейсом для тестирования. Демонстрация включает примеры использования хука с возможностью изменения параметров в реальном времени через интерфейс `Storybook`.

### Примеры использования

- Изменение стиля элемента при наведении: Изменение цвета фона, рамки или других стилей при наведении мыши на элемент.
- Показ дополнительной информации: Отображение всплывающих подсказок или другой информации при наведении на элемент.
- Анимации: Реализация плавных переходов и анимаций, которые активируются при наведении.