### PR TITLE
useFetch

### DIFF
--- a/src/hooks/useFetch/index.module.scss
+++ b/src/hooks/useFetch/index.module.scss
@@ -1,0 +1,48 @@
+.wrapper {
+	height: 90vh;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+
+	img {
+		width: 200px;
+		aspect-ratio: 1 / 1;
+		border-radius: 10px;
+	}
+
+	.info {
+		font-size: 26px;
+		font-weight: 700;
+		font-family: "Montserrat", sans-serif;
+		color: #F37022;
+	}
+
+	.email {
+		font-size: 18px;
+		font-weight: 500;
+		font-family: "Montserrat", sans-serif;
+	}
+	
+	> button {
+		background-color: #F37022;
+		padding: 10px 15px;
+		border: 1px solid #F37022;
+		background-color: white;
+		color: #F37022;
+		border: 1px solid #F37022;
+		border-radius: 5px;
+		font-size: 14px;
+		font-weight: 500;
+		font-family: "Montserrat", sans-serif;
+		transition: all 0.3s ease;
+
+		&:hover {
+			background-color: #F37022;
+			border: 1px solid #F37022;
+			color: white;
+			cursor: pointer;
+			scale: 1.1;
+		} 
+	}
+}

--- a/src/hooks/useFetch/useFetch.stories.tsx
+++ b/src/hooks/useFetch/useFetch.stories.tsx
@@ -1,0 +1,57 @@
+// src/hooks/useFetch/useFetch.stories.tsx
+
+import React from 'react'
+import { Meta, StoryFn } from '@storybook/react'
+import classes from './index.module.scss'
+import { useFetch } from './useFetch'
+
+interface User {
+  name: {
+    first: string
+    last: string
+  }
+  email: string
+  picture: {
+    large: string
+  }
+}
+
+const Demo = () => {
+  const { data, error, loading, refetch } = useFetch<{ results: User[] }>('https://randomuser.me/api/')
+
+  if (loading)
+    return (
+      <div className={classes.wrapper}>
+        <p className={classes.info}>Загрузка...</p>
+      </div>
+    )
+
+  if (error)
+    return (
+      <div className={classes.wrapper}>
+        <p className={classes.info}>Ошибка: {error.message}</p>
+      </div>
+    )
+
+  const { name, email, picture } = data?.results[0] ?? {}
+
+  return (
+    <div className={classes.wrapper}>
+      <img src={picture?.large} alt={`${name?.first} ${name?.last}`} />
+      <h1 className={classes.info}>
+        {name?.first} {name?.last}
+      </h1>
+      <p className={classes.email}>{email}</p>
+      <button onClick={refetch}>Обновить данные</button>
+    </div>
+  )
+}
+
+export default {
+  title: 'Хуки/useFetch',
+  component: Demo,
+} as Meta
+
+const Template: StoryFn = () => <Demo />
+
+export const Default = Template.bind({})

--- a/src/hooks/useFetch/useFetch.ts
+++ b/src/hooks/useFetch/useFetch.ts
@@ -1,0 +1,68 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+
+/**
+ * @name useFetch
+ * @description Хук для выполнения HTTP-запросов с поддержкой кэширования и отмены
+ * @param url - URL, по которому выполняется запрос
+ * @param options - Настройки запроса
+ * @returns { data, error, loading, refetch } - Состояние загрузки, данные и ошибки
+ *
+ * @example
+ * const { data, error, loading, refetch } = useFetch('https://api.example.com/data');
+ */
+
+export function useFetch<T>(url: string, options?: RequestInit) {
+  const cache = useRef<{ [url: string]: { data: T; timestamp: number } }>({})
+  const [loading, setLoading] = useState<boolean>(false)
+  const [data, setData] = useState<T | null>(null)
+  const [error, setError] = useState<Error | null>(null)
+  const [currentUrl, setCurrentUrl] = useState<string>(url)
+  const abortController = useRef<AbortController | null>(null)
+
+  const fetchData = useCallback(async () => {
+    if (abortController.current) {
+      abortController.current.abort()
+    }
+    abortController.current = new AbortController()
+
+    const cacheDuration = 5 * 60 * 1000 // 5 минут
+    const cachedResponse = cache.current[currentUrl]
+    if (cachedResponse && Date.now() - cachedResponse.timestamp < cacheDuration) {
+      setData(cachedResponse.data)
+      setLoading(false)
+
+      return
+    }
+
+    try {
+      setLoading(true)
+      const response = await fetch(currentUrl, {
+        ...options,
+        signal: abortController.current.signal,
+      })
+      if (!response.ok) {
+        throw new Error(`HTTP error! Status: ${response.status}`)
+      }
+      const result: T = await response.json()
+      cache.current[currentUrl] = { data: result, timestamp: Date.now() }
+      setData(result)
+    } catch (error) {
+      if (error instanceof Error && error.name !== 'AbortError') {
+        setError(error)
+      }
+    } finally {
+      setLoading(false)
+      abortController.current = null
+    }
+  }, [currentUrl, options])
+
+  const refetch = useCallback(() => {
+    setCurrentUrl(`${url}?timestamp=${new Date().getTime()}`)
+  }, [url])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  return { data, error, loading, refetch }
+}


### PR DESCRIPTION
### Создание хука `useFetch`
Хук `useFetch` предоставляет функциональность для выполнения `HTTP-запросов` с поддержкой кэширования, удаления устаревших данных и отмены запросов. Он позволяет легко управлять состоянием загрузки, обработки данных и ошибок при выполнении запросов, предоставляя простой и эффективный `API`.

### Документация

> Использование хука `useFetch`

Хук `useFetch` позволяет выполнять `HTTP-запросы` и управлять состоянием загрузки, обработкой данных и ошибок. Это может быть полезно для получения данных с сервера и обновления интерфейса на основе полученных данных.

> Параметры

`url (string): URL`, по которому выполняется запрос.
`options (RequestInit, необязательный)` : Настройки запроса, аналогичные настройкам `fetch`.

> Возвращаемое значение

`data (T | null)` : Данные, полученные в результате запроса.
`error (Error | null)` : Ошибка, возникшая при выполнении запроса.
`loading (boolean)` : Логическое значение, указывающее на состояние загрузки данных.
`refetch (() => void)` : Функция для повторного выполнения запроса.
### История в `Storybook`
Визуальная демонстрация работы хука `useFetch` с интерактивным интерфейсом для тестирования. 
### Примеры использования

- Получение данных с сервера
- Кэширование данных: При повторных запросах к тому же URL данные будут браться из кеша, если они не устарели.
- Обновление данных: Используйте функцию refetch, чтобы обновлять данные по мере необходимости.
- Обработка ошибок: Хук предоставляет простой способ обработки ошибок запросов.