### PR TITLE
useEventListener

### DIFF
--- a/src/hooks/useEventListener/index.module.scss
+++ b/src/hooks/useEventListener/index.module.scss
@@ -1,0 +1,14 @@
+.wrapper {
+	height: 90vh;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+
+	.info {
+		font-size: 30px;
+		font-weight: 700;
+		font-family: "Montserrat", sans-serif;
+		color: #F37022;
+	}
+}

--- a/src/hooks/useEventListener/useEventListener.stories.tsx
+++ b/src/hooks/useEventListener/useEventListener.stories.tsx
@@ -1,0 +1,62 @@
+// src/hooks/useEventListener/useEventListener.stories.tsx
+
+import React, { useState, useRef } from 'react'
+import { Meta, StoryFn } from '@storybook/react'
+import { useEventListener } from './useEventListener'
+import classes from './index.module.scss'
+
+const Demo = () => {
+  const [mousePosition, setMousePosition] = useState<{ x: number; y: number }>({ x: 0, y: 0 })
+  const [keyPressed, setKeyPressed] = useState<string | null>(null)
+  const [isHovered, setIsHovered] = useState(false)
+
+  // Слушатель события движения мыши на документе
+  useEventListener(
+    'mousemove',
+    (event) => {
+      setMousePosition({ x: event.clientX, y: event.clientY })
+    },
+    document,
+  )
+
+  // Слушатель события нажатия клавиши на документе
+  useEventListener(
+    'keydown',
+    (event) => {
+      setKeyPressed(event.key)
+    },
+    document,
+  )
+
+  // Слушатель события наведения на элемент
+  const ref = useRef<HTMLDivElement>(null)
+  useEventListener('mouseover', () => setIsHovered(true), ref.current)
+  useEventListener('mouseout', () => setIsHovered(false), ref.current)
+
+  return (
+    <div className={classes.wrapper}>
+      <div ref={ref}>
+        <p
+          className={classes.info}
+          style={{ transform: isHovered ? 'scale(1.2)' : 'scale(1)', transition: 'all 0.3s' }}>
+          {isHovered ? 'Ты надо мной!' : 'Наведи на меня'}
+        </p>
+      </div>
+      <p className={classes.info} style={{ color: 'black' }}>
+        Положение мыши: X: <code>{mousePosition.x}</code>, Y: <code>{mousePosition.y}</code>
+      </p>
+      <p className={classes.info}>
+        Последнее нажатая клавиша: <code>{keyPressed || 'None'}</code>
+      </p>
+    </div>
+  )
+}
+
+export default {
+  title: 'Хуки/useEventListener',
+  component: Demo,
+} as Meta
+
+const Template: StoryFn = () => <Demo />
+
+export const Default = Template.bind({})

--- a/src/hooks/useEventListener/useEventListener.ts
+++ b/src/hooks/useEventListener/useEventListener.ts
@@ -1,0 +1,77 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * @name useEventListener
+ * @description Хук для добавления и удаления обработчиков событий для различных типов событий и элементов (HTML элементы, window, document).
+ * @param {K} eventName - Имя события, на которое необходимо подписаться.
+ * @param {EventHandler<K>} handler - Функция-обработчик события.
+ * @param {SupportedEventTarget} [element=window] - Элемент, на который нужно повесить обработчик события. По умолчанию — window.
+ * @param {boolean | AddEventListenerOptions} [options] - Опции для addEventListener.
+ *
+ * @example
+ * // Пример использования слушателя события прокрутки на окне:
+ * useEventListener('scroll', (event) => {
+ *   console.log('Scrolled!', event);
+ * });
+ *
+ * @example
+ * // Пример использования слушателя кликов на кнопке:
+ * const buttonRef = useRef<HTMLButtonElement>(null);
+ * useEffect(() => {
+ *   if (buttonRef.current) {
+ *     useEventListener('click', (event) => {
+ *       console.log('Button clicked!', event);
+ *     }, buttonRef.current);
+ *   }
+ * }, []);
+ *
+ * @example
+ * // Пример использования слушателя события клавиатуры на документе с опциями:
+ * useEventListener('keydown', (event) => {
+ *   console.log('Key pressed!', event);
+ * }, document, { capture: true });
+ *
+ * @template K
+ * @param {K} eventName - Имя события, на которое необходимо подписаться.
+ * @param {EventHandler<K>} handler - Функция-обработчик события.
+ * @param {SupportedEventTarget} [element=window] - Элемент, на который нужно повесить обработчик события. По умолчанию — window.
+ * @param {boolean | AddEventListenerOptions} [options] - Опции для addEventListener.
+ */
+
+// Определяем тип для поддерживаемых элементов
+type SupportedEventTarget = HTMLElement | Window | Document
+
+// Определяем тип обработчика событий
+type EventHandler<K extends keyof WindowEventMap> = (event: WindowEventMap[K]) => void
+
+export function useEventListener<K extends keyof WindowEventMap>(
+  eventName: K,
+  handler: EventHandler<K>,
+  element: SupportedEventTarget | null = window, // Разрешаем null здесь
+  options?: boolean | AddEventListenerOptions,
+) {
+  // Используем useRef для сохранения текущего обработчика
+  const savedHandler = useRef<EventHandler<K>>(handler)
+
+  // Обновляем ref с обработчиком, только если он изменился
+  useEffect(() => {
+    savedHandler.current = handler
+  }, [handler])
+
+  useEffect(() => {
+    // Проверяем, поддерживает ли элемент addEventListener
+    const targetElement = element && 'addEventListener' in element ? element : null
+    if (!targetElement) return
+
+    // Создаем обертку для вызова текущего обработчика из useRef
+    const eventListener = (event: Event) => savedHandler.current(event as WindowEventMap[K])
+
+    // Добавляем обработчик события
+    targetElement.addEventListener(eventName, eventListener, options)
+
+    // Убираем обработчик события при размонтировании
+    return () => {
+      targetElement.removeEventListener(eventName, eventListener, options)
+    }
+  }, [eventName, element, options]) // Обновляем useEffect только при изменении eventName, element или options
+}


### PR DESCRIPTION
### Создание хука `useEventListener`
Хук `useEventListener` предоставляет функциональность для добавления и удаления обработчиков событий для различных типов событий и элементов (`HTML элементы, window, document`). Он позволяет легко управлять обработчиками событий на любом поддерживаемом элементе, предоставляя простой API и возможность настройки.

### Документация

> Использование хука `useEventListener`

Хук `useEventListener` позволяет добавлять и удалять обработчики событий на элементы, такие как `window, document и другие HTML элементы`. Это может быть полезно для реализации интерактивных интерфейсов, где важно реагировать на действия пользователя, такие как клики, прокрутка или нажатия клавиш.

> Параметры

`eventName (K)` : Имя события, на которое необходимо подписаться.

`handler (EventHandler)` : Функция-обработчик события.

`element (SupportedEventTarget)` : Элемент, на который нужно повесить обработчик события. По умолчанию — `window`.

`options (boolean | AddEventListenerOptions)` : Опции для `addEventListener`.

> Возвращаемое значение

Хук не возвращает значения, он просто добавляет и удаляет обработчики событий на указанный элемент.

### История в `Storybook`
Визуальная демонстрация работы хука `useEventListener` с интерактивным интерфейсом для тестирования. Демонстрация включает примеры использования хука с возможностью изменения параметров в реальном времени через интерфейс `Storybook`.
### Примеры использования

- Отслеживание прокрутки окна:

```
useEventListener('scroll', (event) => {
  console.log('Scrolled!', event);
});
```

- Отслеживание кликов на кнопке:

```
const buttonRef = useRef<HTMLButtonElement>(null);
useEffect(() => {
  if (buttonRef.current) {
    useEventListener('click', (event) => {
      console.log('Button clicked!', event);
    }, buttonRef.current);
  }
}, []);
```

- Отслеживание нажатий клавиш на документе с опциями:

```
useEventListener('keydown', (event) => {
  console.log('Key pressed!', event);
}, document, { capture: true });
```